### PR TITLE
Improve DB efficiency, add job timeout

### DIFF
--- a/deployment/runtime_configmap.yaml
+++ b/deployment/runtime_configmap.yaml
@@ -15,6 +15,8 @@ data:
       default_resources:
         cpu: 1
         gpu: 1
+      reconcile_interval: 30
+      job_time_limit: 28800
     training_volumes:
       - name: input-data
         pvc_name: cos-ray-output

--- a/runtime_config.yml
+++ b/runtime_config.yml
@@ -6,10 +6,14 @@ trainer_config:
   output_dir: /data/output
   tuning_image: sft-trainer
   image_pull_secrets: all-icr-io
+  # Default resource allocation for a job, if unspecified
   default_resources:
     cpu: 1
     gpu: 0
+  # How often full reconciles should run, in seconds
   reconcile_interval: 30
+  # Time limit on job runs, in seconds. If >0, job will be terminated if not completed in time.
+  job_time_limit: 28800
 training_volumes:
   - name: input-data
     pvc_name: cos-ray-test
@@ -25,3 +29,4 @@ datastore:
     host: localhost
     port: 6379
     db_num: 0
+    user: ""

--- a/train_conductor/plugins/redis.py
+++ b/train_conductor/plugins/redis.py
@@ -78,8 +78,13 @@ class RedisHelper(DatabaseBase):
     def iterate_entries(self, filter: str = None, cursor=None):
         return self._client.scan(cursor=cursor, match=filter)
 
-    def read_many_entries(self, keys):
-        return self._client.mget(keys)
+    def read_many_entries(self, keys: list[str]):
+            pipe = self._client.pipeline()
+            for key in keys:
+                pipe.hgetall(key)
+            responses = pipe.execute()
+
+            return dict(zip(keys, responses))
 
     def publish_data(self, key):
         self._client.publish("train_conductor", str(key))


### PR DESCRIPTION
Improving DB efficiency of entry lookup on Full Reconcile. 
Since there is no standard way of retrieving a bunch of entries AND their values at one time in Redis, I am executing a "scan" to page through all the Redis entries, and using a "pipeline" to do an "hgetall" on each entries in batches on the Redis side. This way, we don't have to execute an "hgetall" on the client side for every single entry individually.

I also added job timeouts with a configurable value in the runtime yaml.