### PR TITLE
Add "number of GPUs" as a tuning parameter to train conductor

### DIFF
--- a/train_conductor/interfaces/trainconductor.proto
+++ b/train_conductor/interfaces/trainconductor.proto
@@ -68,6 +68,7 @@ message TrainingParameters {
   optional string tokenizer_name_or_path = 33;
 
   optional bool overwrite_output_dir = 34;
+  optional int32 num_gpus = 35;
 }
 
 message TrainingInfoRequest {

--- a/train_conductor/modules/watcher.py
+++ b/train_conductor/modules/watcher.py
@@ -146,7 +146,8 @@ class Watcher:
                         job_id=job_id,
                         image=self.tuning_image,
                         image_pull_secrets=self.config.trainer_config.image_pull_secrets,
-                        gpus=self.config.trainer_config.default_resources.gpu,
+                        gpus=env_vars.get("num_gpus")
+                        or self.config.trainer_config.default_resources.gpu,
                         env_vars=env_vars,
                     )
                     return
@@ -343,7 +344,9 @@ class Watcher:
             volume_mounts=volume_mounts,
             image=image,
             env=[
-                client.V1EnvVar(name="SFT_TRAINER_CONFIG_JSON_ENV_VAR", value=env_var_string),
+                client.V1EnvVar(
+                    name="SFT_TRAINER_CONFIG_JSON_ENV_VAR", value=env_var_string
+                ),
                 client.V1EnvVar(name="ALLOW_DOWNLOADS", value="true"),
             ],
             resources=client.V1ResourceRequirements(limits={"nvidia.com/gpu": gpus}),


### PR DESCRIPTION
Accept "Number of GPUs" as a parameter in the training servicer. This will deploy the target tuning job on the specified number of GPUs.