### PR TITLE
fix bias param from float to string

### DIFF
--- a/train_conductor/interfaces/trainconductor.proto
+++ b/train_conductor/interfaces/trainconductor.proto
@@ -58,7 +58,7 @@ message TrainingParameters {
   optional int32 r = 25;
   optional int32 lora_alpha = 26;
   repeated string target_modules = 27;
-  optional float bias = 28;
+  optional string bias = 28;
   optional float lora_dropout = 29;
 
   /* PT */


### PR DESCRIPTION
As seen in [HF docs](https://huggingface.co/docs/peft/en/package_reference/lora#peft.LoraConfig.bias) and in [HF repo](https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora/config.py#L66), the value for bias used for Lora tuning should be a string and not a float.